### PR TITLE
fixato l'invio del messaggio embed su altro canale

### DIFF
--- a/jest-mongodb-config.js
+++ b/jest-mongodb-config.js
@@ -4,7 +4,7 @@ module.exports = {
       dbName: 'coders_hub_bot',
     },
     binary: {
-      version: '4.0.2',
+      version: '4.4.1',
       skipMD5: true,
     },
     autoStart: false,

--- a/src/commands/embed/embed_example.js
+++ b/src/commands/embed/embed_example.js
@@ -9,7 +9,11 @@ module.exports = class EmbedExemple extends Commands {
     this.example = ''
     this.description = 'Scarica il file di esempio .json per creare un embed'
     this.timer = 0
-    this.access = [client._botSettings.rules.Admin, client._botSettings.rules.Moderatore]
+    this.access = [
+      client._botSettings.rules.Admin,
+      client._botSettings.rules.Moderatore,
+      client._botSettings.rules.Collaboratore,
+    ]
     this.displayHelp = 1
   }
 


### PR DESCRIPTION
fix dell'invio del messaggio embed su altro canale (per quanto al momento permetta di mandare il messaggio su canali dove lo user non ha diritti ma ce li ha il bot).

Per pulizia rimozione del messaggio di comando non appena eseguito